### PR TITLE
Multiple updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+### 2018-10-17 0.1.5
+- Updated error code mappers
+- Added more constants
+- Added support for handling servicebus response properties in the request/response operations
+- Fixed a bug in the `sendRequest()` method which ensures that the operation will actually be 
+retried, rather than returning the previously rejected promise.
+- Removed dependency from `uuid`, since `rhea` supports basic uuid operations.
+
 ### 2018-10-03 0.1.4
 - `ConnectionConfig.entityPath` is optional. Hence, `ConnectionConfig.create()` and
 `ConnectionConfig.validate()` will not throw an error if `entityPath` is not defined. However,

--- a/lib/ConnectionContextBase.ts
+++ b/lib/ConnectionContextBase.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Connection, ConnectionOptions } from "rhea-promise";
+import { Connection, ConnectionOptions, generate_uuid } from "rhea-promise";
 import { CbsClient } from "./cbs";
 import { DataTransformer, DefaultDataTransformer } from "./dataTransformer";
 import { TokenProvider } from "./auth/token";
@@ -9,7 +9,6 @@ import { ConnectionConfig } from "./connectionConfig";
 import { SasTokenProvider } from "./auth/sas";
 import * as Constants from "./util/constants";
 import * as os from "os";
-import * as uuid from "uuid/v4";
 
 /**
  * @interface ConnectionContextBase
@@ -152,11 +151,11 @@ export module ConnectionContextBase {
     };
 
     const connection = new Connection(connectionOptions);
-    const connectionLock = `${Constants.establishConnection}-${uuid()}`;
+    const connectionLock = `${Constants.establishConnection}-${generate_uuid()}`;
     const connectionContextBase: ConnectionContextBase = {
       wasConnectionCloseCalled: false,
       connectionLock: connectionLock,
-      negotiateClaimLock: `${Constants.negotiateClaim}-${uuid()}`,
+      negotiateClaimLock: `${Constants.negotiateClaim}-${generate_uuid()}`,
       connection: connection,
       connectionId: connection.id,
       cbsSession: new CbsClient(connection, connectionLock),

--- a/lib/cbs.ts
+++ b/lib/cbs.ts
@@ -4,9 +4,8 @@
 import { TokenInfo } from "./auth/token";
 import {
   EventContext, ReceiverOptions, Message as AmqpMessage, SenderEvents, ReceiverEvents,
-  Connection, SenderOptions
+  Connection, SenderOptions, generate_uuid
 } from "rhea-promise";
-import * as uuid from "uuid/v4";
 import * as Constants from "./util/constants";
 import * as log from "./log";
 import { translate } from "./errors";
@@ -35,12 +34,12 @@ export class CbsClient {
   /**
    * @property {string} replyTo CBS replyTo - The reciever link name that the service should reply to.
    */
-  readonly replyTo: string = `${Constants.cbsReplyTo}-${uuid()}`;
+  readonly replyTo: string = `${Constants.cbsReplyTo}-${generate_uuid()}`;
   /**
    * @property {string} cbsLock The unqiue lock name per $cbs session per connection that is used to
    * acquire the lock for establishing a cbs session if one does not exist for an aqmp connection.
    */
-  readonly cbsLock: string = `${Constants.negotiateCbsKey}-${uuid()}`;
+  readonly cbsLock: string = `${Constants.negotiateCbsKey}-${generate_uuid()}`;
   /**
    * @property {string} connectionLock The unqiue lock name per connection that is used to
    * acquire the lock for establishing an amqp connection if one does not exist.
@@ -159,7 +158,7 @@ export class CbsClient {
     try {
       const request: AmqpMessage = {
         body: tokenObject.token,
-        message_id: uuid(),
+        message_id: generate_uuid(),
         reply_to: this.replyTo,
         to: this.endpoint,
         application_properties: {

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -36,6 +36,31 @@ export enum ConditionStatusMapper {
  */
 export enum ConditionErrorNameMapper {
   /**
+   * Error is thrown when the address is already in use.
+   */
+  "com.microsoft:address-already-in-use" = "AddressAlreadyInUseError",
+  /**
+   * Error is thrown when the store lock is lost.
+   */
+  "com.microsoft:store-lock-lost" = "StoreLockLostError",
+  /**
+   * Error is thrown when a matching subscription is not found.
+   */
+  "com.microsoft:no-matching-subscription" = "NoMatchingSubscriptionError",
+  /**
+   * Error is thrown when an attempt is made to access a parition that is not owned by the
+   * requesting entity.
+   */
+  "com.microsoft:partition-not-owned" = "PartitionNotOwnedError",
+  /**
+   * Error is thrown when access to publisher has been revoked.
+   */
+  "com.microsoft:publisher-revoked" = "PublisherRevokedError",
+  /**
+   * Error is thrown when an attempt is made to create an entity that already exists.
+   */
+  "com.microsoft:entity-already-exists" = "MessagingEntityAlreadyExistsError",
+  /**
    * Error is thrown when trying to access/connect to a disabled messaging entity.
    */
   "com.microsoft:entity-disabled" = "MessagingEntityDisabledError",
@@ -59,6 +84,14 @@ export enum ConditionErrorNameMapper {
    * Error for signaling general communication errors related to messaging operations.
    */
   "amqp:not-found" = "ServiceCommunicationError",
+  /**
+   * Error is thrown when the message is not found.
+   */
+  "com.microsoft:message-not-found" = "MessageNotFoundError",
+  /**
+   * Error is thrown when relay is not found.
+   */
+  "com.microsoft:relay-not-found" = "RelayNotFoundError",
   /**
    * Error is thrown when a feature is not implemented yet but the placeholder is present.
    */
@@ -158,7 +191,7 @@ export enum ConditionErrorNameMapper {
   /**
    * Error is thrown when an attach was received using a handle that is already in use for an attached link.
    */
-  "amqp:session:handle-in-use" = "HanldeInUseError",
+  "amqp:session:handle-in-use" = "HandleInUseError",
   /**
    * Error is thrown when a frame (other than attach) was received referencing a handle which is not
    * currently in use of an attached link.
@@ -206,6 +239,31 @@ export enum ConditionErrorNameMapper {
  */
 export enum ErrorNameConditionMapper {
   /**
+   * Error is thrown when the address is already in use.
+   */
+  AddressAlreadyInUseError = "com.microsoft:address-already-in-use",
+  /**
+   * Error is thrown when the store lock is lost.
+   */
+  StoreLockLostError = "com.microsoft:store-lock-lost",
+  /**
+   * Error is thrown when a matching subscription is not found.
+   */
+  NoMatchingSubscriptionError = "com.microsoft:no-matching-subscription",
+  /**
+   * Error is thrown when an attempt is made to access a parition that is not owned by the
+   * requesting entity.
+   */
+  PartitionNotOwnedError = "com.microsoft:partition-not-owned",
+  /**
+   * Error is thrown when access to publisher has been revoked.
+   */
+  PublisherRevokedError = "com.microsoft:publisher-revoked",
+  /**
+   * Error is thrown when an attempt is made to create an entity that already exists.
+   */
+  MessagingEntityAlreadyExistsError = "com.microsoft:entity-already-exists",
+  /**
    * Error is thrown when trying to access/connect to a disabled messaging entity.
    */
   MessagingEntityDisabledError = "com.microsoft:entity-disabled",
@@ -229,6 +287,14 @@ export enum ErrorNameConditionMapper {
    * Error for signaling general communication errors related to messaging operations.
    */
   ServiceCommunicationError = "amqp:not-found",
+  /**
+   * Error is thrown when message is not found.
+   */
+  MessageNotFoundError = "com.microsoft:message-not-found",
+  /**
+   * Error is thrown when relay is not found.
+   */
+  RelayNotFoundError = "com.microsoft:relay-not-found",
   /**
    * Error is thrown when a feature is not implemented yet but the placeholder is present.
    */
@@ -320,7 +386,7 @@ export enum ErrorNameConditionMapper {
   /**
    * Error is thrown when an attach was received using a handle that is already in use for an attached link.
    */
-  HanldeInUseError = "amqp:session:handle-in-use",
+  HandleInUseError = "amqp:session:handle-in-use",
   /**
    * Error is thrown when a frame (other than attach) was received referencing a handle which is not
    * currently in use of an attached link.

--- a/lib/requestResponseLink.ts
+++ b/lib/requestResponseLink.ts
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import * as uuid from "uuid/v4";
 import * as Constants from "./util/constants";
 import { retry, RetryConfig, RetryOperationType } from "./retry";
 import {
   Session, Connection, Sender, Receiver, Message as AmqpMessage, EventContext, AmqpError,
-  SenderOptions, ReceiverOptions, ReceiverEvents, ReqResLink
+  SenderOptions, ReceiverOptions, ReceiverEvents, ReqResLink, generate_uuid
 } from "rhea-promise";
 import { translate, ConditionStatusMapper } from "./errors";
 import * as log from "./log";
@@ -81,7 +80,7 @@ export class RequestResponseLink implements ReqResLink {
       throw new Error("request is a required parameter and must be of type 'object'.");
     }
 
-    if (!request.message_id) request.message_id = uuid();
+    if (!request.message_id) request.message_id = generate_uuid();
 
     if (!options) options = {};
 

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -98,4 +98,4 @@ export const operations = {
   addRule: "com.microsoft:add-rule",
   removeRule: "com.microsoft:remove-rule",
   enumerateRules: "com.microsoft:enumerate-rules"
-}
+};

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -73,3 +73,29 @@ export const defaultRetryAttempts = 3;
 export const defaultConnectionRetryAttempts = 150;
 export const defaultDelayBetweenOperationRetriesInSeconds = 5;
 export const defaultDelayBetweenRetriesInSeconds = 15;
+export const receiverSettleMode = "receiver-settle-mode";
+export const dispositionStatus = "disposition-status";
+export const fromSequenceNumber = "from-sequence-number";
+export const messageCount = "message-count";
+export const lockTokens = "lock-tokens";
+export const sequenceNumbers = "sequence-numbers";
+export const deadLetterReason = "deadletter-reason";
+export const deadLetterDescription = "deadletter-description";
+export const propertiesToModify = "properties-to-modify";
+export const trackingId = "com.microsoft:tracking-id";
+export const serverTimeout = "com.microsoft:server-timeout";
+export const operations = {
+  cancelScheduledMessage: "com.microsoft:cancel-scheduled-message",
+  scheduleMessage: "com.microsoft:schedule-message",
+  renewLock: "com.microsoft:renew-lock",
+  peekMessage: "com.microsoft:peek-message",
+  receiveBySequenceNumber: "com.microsoft:receive-by-sequence-number",
+  updateDisposition: "com.microsoft:update-disposition",
+  renewSessionLock: "com.microsoft:renew-session-lock",
+  setSessionState: "com.microsoft:set-session-state",
+  getSessionState: "com.microsoft:get-session-state",
+  enumerateSessions: "com.microsoft:get-message-sessions",
+  addRule: "com.microsoft:add-rule",
+  removeRule: "com.microsoft:remove-rule",
+  enumerateRules: "com.microsoft:enumerate-rules"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/amqp-common",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -115,7 +115,7 @@
     },
     "@types/async-lock": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/@types/async-lock/-/async-lock-1.1.0.tgz",
       "integrity": "sha512-Eo8EXiqmChtkt0ETf6AQ8aiDHT3Tht6OuMSa3/9nfuyqFimp7ZwPMiufsA56A7ZUGBuwFzH860jO0d8n0lETtg==",
       "dev": true
     },
@@ -142,7 +142,7 @@
     },
     "@types/dotenv": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-4.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/@types/dotenv/-/dotenv-4.0.3.tgz",
       "integrity": "sha512-mmhpINC/HcLGQK5ikFJlLXINVvcxhlrV+ZOUJSN7/ottYl+8X4oSXzS9lBtDkmWAl96EGyGyLrNvk9zqdSH8Fw==",
       "dev": true,
       "requires": {
@@ -156,18 +156,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.34.tgz",
-      "integrity": "sha512-alypNiaAEd0RBGXoWehJ2gchPYCITmw4CYBoB5nDlji8l8on7FsklfdfIs4DDmgpKLSX3OF3ha6SV+0W7cTzUA=="
-    },
-    "@types/uuid": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
-      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
+      "version": "8.10.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.36.tgz",
+      "integrity": "sha512-SL6KhfM7PTqiFmbCW3eVNwVBZ+88Mrzbuvn9olPsfv43mbiWaFY+nRcz/TGGku0/lc2FepdMbImdMY1JrQ+zbw=="
     },
     "adal-node": {
       "version": "0.1.28",
@@ -321,7 +312,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -463,9 +453,9 @@
       "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
     },
     "debug": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -491,9 +481,9 @@
       "dev": true
     },
     "dotenv": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
-      "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw==",
       "dev": true
     },
     "duplexer": {
@@ -505,7 +495,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -563,23 +552,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        }
       }
     },
     "fs.realpath": {
@@ -758,8 +737,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
       "version": "2.5.1",
@@ -3135,9 +3113,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
     },
     "source-map": {
@@ -3171,9 +3149,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
+      "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -3304,8 +3282,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -3314,9 +3291,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
-      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
+      "integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==",
       "dev": true
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/amqp-common",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -12,8 +12,7 @@
     "is-buffer": "^2.0.2",
     "jssha": "^2.3.1",
     "ms-rest-azure": "^2.5.9",
-    "tslib": "^1.9.3",
-    "uuid": "^3.3.2"
+    "tslib": "^1.9.3"
   },
   "peerDependencies": {
     "rhea-promise": "^0.1.6"
@@ -26,7 +25,6 @@
     "@types/dotenv": "^4.0.3",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.37",
-    "@types/uuid": "^3.4.3",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "dotenv": "^6.0.0",


### PR DESCRIPTION
- Updated error code mappers
- Added more constants
- Added support for handling servicebus response properties in the request/response operations
- Fixed a bug in the `sendRequest()` method which ensures that the operation will actually be 
retried, rather than returning the previously rejected promise.
- Removed dependency from `uuid`, since `rhea` supports basic uuid operations.
