### PR TITLE
Enable the esModuleInterop compiler flag and address compiler warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### 2019-1-8 0.1.10
+- Enabled esModuleInterop flag for the TypeScript compiler
+
 ### 2018-12-15 0.1.9
 - Added constants for rule and filter descriptors as defined in the [service bus docs](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-request-response#rule-operations)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
-### 2019-1-8 0.1.10
-- Enabled esModuleInterop flag for the TypeScript compiler
+### 2019-1-10 1.0.0
+- Enabled esModuleInterop flag for the TypeScript compiler and mark the release stable.
 
 ### 2018-12-15 0.1.9
 - Added constants for rule and filter descriptors as defined in the [service bus docs](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-request-response#rule-operations)

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-### 2019-1-10 1.0.0
+### 2019-1-11 1.0.0-preview.1
 - Enabled esModuleInterop flag for the TypeScript compiler and mark the release stable.
 
 ### 2018-12-15 0.1.9

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 ### 2019-1-11 1.0.0-preview.1
-- Enabled esModuleInterop flag for the TypeScript compiler and mark the release stable.
+- Enabled esModuleInterop flag for the TypeScript compiler.
 
 ### 2018-12-15 0.1.9
 - Added constants for rule and filter descriptors as defined in the [service bus docs](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-request-response#rule-operations)

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import * as debugModule from "debug";
+import debugModule from "debug";
 /**
  * @ignore
  * log statements for cbs

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import * as AsyncLock from "async-lock";
+import AsyncLock from "async-lock";
 export { AsyncLock };
 /**
  * Describes the options that can be provided to create an async lock.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/amqp-common",
-  "version": "0.1.10",
+  "version": "1.0.0-preview.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/amqp-common",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/amqp-common",
-  "version": "0.1.10",
+  "version": "1.0.0",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/amqp-common",
-  "version": "1.0.0",
+  "version": "1.0.0-preview.1",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/amqp-common",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/tests/retry.spec.ts
+++ b/tests/retry.spec.ts
@@ -6,7 +6,7 @@ import {
   retry, translate, RetryConfig, RetryOperationType, Constants, delay, MessagingError
 } from "../lib";
 import * as chai from "chai";
-import * as debugModule from "debug";
+import debugModule from "debug";
 const debug = debugModule("azure:amqp-common:retry-spec");
 const should = chai.should();
 import * as dotenv from "dotenv";

--- a/tests/tokenProvider.spec.ts
+++ b/tests/tokenProvider.spec.ts
@@ -4,7 +4,7 @@
 import "mocha";
 import * as chai from "chai";
 chai.should();
-import * as debugModule from "debug";
+import debugModule from "debug";
 const debug = debugModule("azure:amqp-common:token-spec");
 import { SasTokenProvider, IotSasTokenProvider } from "../lib";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noImplicitReturns": true,
     "outDir": "dist",
     "allowJs": false,
+    "esModuleInterop": true,
     "noUnusedLocals":true,
     "strict": true,
     "declaration": true,


### PR DESCRIPTION
Enable the esModuleInterop compiler option to emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports.

Addressing the compiler errors that showed up after that change.