### PR TITLE
Allow connnection strings to contain whitespace

### DIFF
--- a/lib/connectionConfig/connectionConfig.ts
+++ b/lib/connectionConfig/connectionConfig.ts
@@ -68,6 +68,10 @@ export namespace ConnectionConfig {
       throw new Error("'connectionString' is a required parameter and must be of type: 'string'.");
     }
     const parsedCS = parseConnectionString<ServiceBusConnectionStringModel>(connectionString);
+    if (!parsedCS.Endpoint) {
+      throw new Error("Connection string is missing Endpoint.");
+    }
+
     if (!parsedCS.Endpoint.endsWith("/")) parsedCS.Endpoint += "/";
     const result: ConnectionConfig = {
       connectionString: connectionString,

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -99,13 +99,12 @@ export type ParsedOutput<T> = {
 export function parseConnectionString<T>(connectionString: string): ParsedOutput<T> {
   return connectionString.trim().split(';').reduce((acc, part) => {
     part = part.trim();
-    const splitIndex = part.indexOf('=');
-
     if (part === '') {
       // parts can be empty
       return acc;
     }
 
+    const splitIndex = part.indexOf('=');
     if (splitIndex === -1) {
       throw new Error("Connection string malformed: each part of the connection string must have an `=` assignment.");
     }

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -112,6 +112,14 @@ export function parseConnectionString<T>(connectionString: string): ParsedOutput
     const key = part.substring(0, splitIndex).trim();
     const value = part.substring(splitIndex + 1).trim();
 
+    if (key === '') {
+      throw new Error('Connection string malformed: missing key for assignment');
+    }
+
+    if (value === '') {
+      throw new Error('Connection string malformed: missing value for assignment');
+    }
+
     return {
       ...acc,
       [key]: value

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -97,11 +97,15 @@ export type ParsedOutput<T> = {
  * @returns {ParsedOutput<T>} ParsedOutput<T>.
  */
 export function parseConnectionString<T>(connectionString: string): ParsedOutput<T> {
-  return connectionString.trim().split(';').reduce((acc, part) => {
+  const output: { [k: string]: string } = {};
+  const parts = connectionString.trim().split(';');
+
+  for (let part of parts) {
     part = part.trim();
+
     if (part === '') {
       // parts can be empty
-      return acc;
+      continue;
     }
 
     const splitIndex = part.indexOf('=');
@@ -116,11 +120,10 @@ export function parseConnectionString<T>(connectionString: string): ParsedOutput
 
     const value = part.substring(splitIndex + 1).trim();
 
-    return {
-      ...acc,
-      [key]: value
-    };
-  }, {} as any);
+    output[key] = value;
+  }
+
+  return output as any;
 }
 
 /**

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -110,15 +110,11 @@ export function parseConnectionString<T>(connectionString: string): ParsedOutput
     }
 
     const key = part.substring(0, splitIndex).trim();
-    const value = part.substring(splitIndex + 1).trim();
-
     if (key === '') {
       throw new Error('Connection string malformed: missing key for assignment');
     }
 
-    if (value === '') {
-      throw new Error('Connection string malformed: missing value for assignment');
-    }
+    const value = part.substring(splitIndex + 1).trim();
 
     return {
       ...acc,

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -57,15 +57,14 @@ describe("ConnectionConfig", function () {
       done();
     });
 
-    it("requires a value after an assignment", done => {
+    it("allows an empty value after an assignment", done => {
       const connectionString = `
-        EntityPath=;
+        Endpoint = sb://hostname.servicebus.windows.net/;
+        SharedAccessKey=;
       `;
-
-      should.throw(() => {
-        ConnectionConfig.create(connectionString);
-      }, /Connection string malformed/);
-
+      const config = ConnectionConfig.create(connectionString);
+      config.should.have.property("host").that.equals("hostname.servicebus.windows.net");
+      config.should.have.property("sharedAccessKey").that.equals("");
       done();
     });
 

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -45,6 +45,30 @@ describe("ConnectionConfig", function () {
       done();
     });
 
+    it("requires a value before an assignment", done => {
+      const connectionString = `
+        = something;
+      `;
+
+      should.throw(() => {
+        ConnectionConfig.create(connectionString);
+      }, /Connection string malformed/);
+
+      done();
+    });
+
+    it("requires a value after an assignment", done => {
+      const connectionString = `
+        EntityPath=;
+      `;
+
+      should.throw(() => {
+        ConnectionConfig.create(connectionString);
+      }, /Connection string malformed/);
+
+      done();
+    });
+
     it("requires an assignment for each part", done => {
       const connectionString = `
         EntityPath;
@@ -53,6 +77,18 @@ describe("ConnectionConfig", function () {
       should.throw(() => {
         ConnectionConfig.create(connectionString);
       }, /Connection string malformed/);
+      done();
+    });
+
+    it("requires that Endpoint be present in the connection string", done => {
+      const connectionString = `
+        EntityPath=ep;
+      `;
+
+      should.throw(() => {
+        ConnectionConfig.create(connectionString);
+      }, /missing Endpoint/);
+
       done();
     });
   });

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -29,6 +29,32 @@ describe("ConnectionConfig", function () {
       should.not.exist(config.entityPath);
       done();
     });
+
+    it("handles arbitrary whitespace around ; and = elements", done => {
+      const connectionString = `
+        Endpoint = sb://hostname.servicebus.windows.net/;
+        SharedAccessKeyName = sakName;
+        SharedAccessKey = sak;
+        EntityPath = ep;
+      `;
+      const config = ConnectionConfig.create(connectionString);
+      config.should.have.property("host").that.equals("hostname.servicebus.windows.net");
+      config.should.have.property("sharedAccessKeyName").that.equals("sakName");
+      config.should.have.property("sharedAccessKey").that.equals("sak");
+      config.should.have.property("entityPath").that.equals("ep");
+      done();
+    });
+
+    it("requires an assignment for each part", done => {
+      const connectionString = `
+        EntityPath;
+      `;
+
+      should.throw(() => {
+        ConnectionConfig.create(connectionString);
+      }, /Connection string malformed/);
+      done();
+    });
   });
 
   describe("EventHub", function () {


### PR DESCRIPTION
... and require they actually assign something, else throw an error.

I've documented what I think the EBNF for the connection string. Happy to remove this comment before checkin (or make it not show up in end-user docs), but it seems useful for discussion purposes.

Gist is: whitespace is allowed between `;` and `=` and their surrounding syntax. Each part must contain an `=` else an error is thrown.

Fixes #18.