### PR TITLE
Remove $cbs session

### DIFF
--- a/lib/cbs.ts
+++ b/lib/cbs.ts
@@ -176,6 +176,7 @@ export class CbsClient {
     }
   }
 
+
   /**
    * Closes the AMQP cbs session to the EventHub/ServiceBus for this client,
    * returning a promise that will be resolved when disconnection is completed.
@@ -191,6 +192,25 @@ export class CbsClient {
       }
     } catch (err) {
       const msg = `An error occurred while closing the cbs link: ${err.stack || JSON.stringify(err)}.`;
+      log.error("[%s] %s", this.connection.id, msg);
+      throw new Error(msg);
+    }
+  }
+
+  /**
+   * Removes the AMQP cbs session to the EventHub/ServiceBus for this client,
+   * @return {Promise<void>}
+   */
+  async remove(): Promise<void> {
+    try {
+      if (this._cbsSenderReceiverLink) {
+        const cbsLink = this._cbsSenderReceiverLink;
+        this._cbsSenderReceiverLink = undefined;
+        await cbsLink!.remove();
+        log.cbs("[%s] Successfully removed the cbs session.", this.connection.id);
+      }
+    } catch (err) {
+      const msg = `An error occurred while removing the cbs link: ${err.stack || JSON.stringify(err)}.`;
       log.error("[%s] %s", this.connection.id, msg);
       throw new Error(msg);
     }

--- a/lib/requestResponseLink.ts
+++ b/lib/requestResponseLink.ts
@@ -186,6 +186,16 @@ export class RequestResponseLink implements ReqResLink {
   }
 
   /**
+   * Removes the sender, receiver link and it's underlying session.
+   * @returns {Promise<void>} Promise<void>
+   */
+  async remove(): Promise<void> {
+    await this.sender.remove();
+    await this.receiver.remove();
+    await this.session.remove();
+  }
+
+  /**
    * Creates an amqp request/response link.
    *
    * @param {Connection} connection The amqp connection.


### PR DESCRIPTION
Created a new method that removes $cbs sender, receiver link and it's underlying session.