### PR TITLE
Remove unnecessary promise of  $cbs link remove() method.

### DIFF
--- a/lib/cbs.ts
+++ b/lib/cbs.ts
@@ -201,12 +201,12 @@ export class CbsClient {
    * Removes the AMQP cbs session to the EventHub/ServiceBus for this client,
    * @return {Promise<void>}
    */
-  async remove(): Promise<void> {
+  remove(): void {
     try {
       if (this._cbsSenderReceiverLink) {
         const cbsLink = this._cbsSenderReceiverLink;
         this._cbsSenderReceiverLink = undefined;
-        await cbsLink!.remove();
+        cbsLink!.remove();
         log.cbs("[%s] Successfully removed the cbs session.", this.connection.id);
       }
     } catch (err) {

--- a/lib/cbs.ts
+++ b/lib/cbs.ts
@@ -199,7 +199,7 @@ export class CbsClient {
 
   /**
    * Removes the AMQP cbs session to the EventHub/ServiceBus for this client,
-   * @return {Promise<void>}
+   * @returns {void} void
    */
   remove(): void {
     try {

--- a/lib/requestResponseLink.ts
+++ b/lib/requestResponseLink.ts
@@ -189,10 +189,10 @@ export class RequestResponseLink implements ReqResLink {
    * Removes the sender, receiver link and it's underlying session.
    * @returns {Promise<void>} Promise<void>
    */
-  async remove(): Promise<void> {
-    await this.sender.remove();
-    await this.receiver.remove();
-    await this.session.remove();
+  remove(): void {
+    this.sender.remove();
+    this.receiver.remove();
+    this.session.remove();
   }
 
   /**

--- a/lib/requestResponseLink.ts
+++ b/lib/requestResponseLink.ts
@@ -187,7 +187,7 @@ export class RequestResponseLink implements ReqResLink {
 
   /**
    * Removes the sender, receiver link and it's underlying session.
-   * @returns {Promise<void>} Promise<void>
+   * @returns {void} void
    */
   remove(): void {
     this.sender.remove();


### PR DESCRIPTION
## Description

#33 This PR removes unnecessary promise of remove() method for RequestResponseLink class.
