### PR TITLE
Skip rhea dependency

### DIFF
--- a/lib/ConnectionContextBase.ts
+++ b/lib/ConnectionContextBase.ts
@@ -7,7 +7,6 @@ import { DataTransformer, DefaultDataTransformer } from "./dataTransformer";
 import { TokenProvider } from "./auth/token";
 import { ConnectionConfig } from "./connectionConfig";
 import { SasTokenProvider } from "./auth/sas";
-import rhea from "rhea";
 
 import * as Constants from "./util/constants";
 import * as os from "os";
@@ -141,7 +140,7 @@ export module ConnectionContextBase {
     if (userAgent.length > Constants.maxUserAgentLength) {
       throw new Error(
         `The user-agent string cannot be more than 128 characters in length.` +
-        `The given user-agent string is: ${userAgent} with length: ${userAgent.length}`
+          `The given user-agent string is: ${userAgent} with length: ${userAgent.length}`
       );
     }
 
@@ -162,17 +161,19 @@ export module ConnectionContextBase {
       operationTimeoutInSeconds: parameters.operationTimeoutInSeconds
     };
 
-    if (parameters.config.webSocket || (typeof window !== "undefined" && (window as any).WebSocket)) {
+    if (
+      parameters.config.webSocket ||
+      (typeof window !== "undefined" && (window as any).WebSocket)
+    ) {
       const socket = parameters.config.webSocket || (window as any).WebSocket;
-      // TODO: expose websocket_connect via rhea-promise
-      const ws = rhea.websocket_connect(socket);
       const host = parameters.config.host;
-      const endpoint = parameters.config.webSocketEndpointPath || '';
+      const endpoint = parameters.config.webSocketEndpointPath || "";
 
-      // connectionOptions is cast to any to work around type errors.
-      // The errors seem spurious and so are ignored.
-      (connectionOptions.connection_details as any) =
-        ws(`wss://${host}:443/${endpoint}`, ["AMQPWSB10"], {});
+      connectionOptions.webSocketOptions = {
+        webSocket: socket,
+        url: `wss://${host}:443/${endpoint}`,
+        protocol: ["AMQPWSB10"]
+      };
     }
 
     const connection = new Connection(connectionOptions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4746,22 +4746,22 @@
       "dev": true
     },
     "rhea": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/rhea/-/rhea-0.3.9.tgz",
-      "integrity": "sha512-16mqaARtj9ZgiYmD5F9uwcgvy5pOB64mWIbkBgrje4zEByIBjHdYB25EyeWb3baiI9OYAYMWb2rnqBfyv5weOg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-1.0.2.tgz",
+      "integrity": "sha512-ZbF1fe90TIu+nhzu5vvf9Xg4OhWO2p2FSGv97SBwPn2CpDy0CRjOxGQYu2eeqSukmZc9D+aQX6lOMQUF0pO16g==",
       "dev": true,
       "requires": {
         "debug": "0.8.0 - 3.5.0"
       }
     },
     "rhea-promise": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-0.1.13.tgz",
-      "integrity": "sha512-nfVsWdzIukY5mN5rPA4kiV8eutNEOr2GmweOkE7qMAeDeXwWlM/bvcLXaJn+Hb0GygOYHdQfMqa/onDRpK+V1A==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-0.1.14.tgz",
+      "integrity": "sha512-3wvslFhKfHDU9wxwLIO6K4gB8/h1PF/J17PeknqawDowVwIdJoupqj/QUBuflFr6ho/dO7mLbU71x00brmO+8w==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
-        "rhea": "^0.3.5",
+        "rhea": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "stream": "stream-browserify"
   },
   "peerDependencies": {
-    "rhea": "^0.3.9",
-    "rhea-promise": "^0.1.13"
+    "rhea-promise": "^0.1.14"
   },
   "devDependencies": {
     "@azure/ms-rest-js": "^1.7.0",
@@ -54,8 +53,7 @@
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^13.3.0",
-    "rhea": "^0.3.9",
-    "rhea-promise": "^0.1.13",
+    "rhea-promise": "^0.1.14",
     "rimraf": "^2.6.2",
     "rollup": "^1.1.2",
     "rollup-plugin-commonjs": "^9.2.0",


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- While adding browser support in #29, we took a dependency on `rhea`. This PR is to instead use web socket related rhea features via rhea-promise and so avoiding the new dependency

cc @bterlson, @AlexGhiondea 
