### PR TITLE
Move @azure/ms-rest-js to a dep

### DIFF
--- a/lib/retry.ts
+++ b/lib/retry.ts
@@ -2,11 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { translate, MessagingError } from "./errors";
-import { delay } from "./util/utils";
+import { delay, isNode } from "./util/utils";
 import * as log from "./log";
 import { defaultRetryAttempts, defaultDelayBetweenRetriesInSeconds } from "./util/constants";
 import { resolve } from "dns";
-import { isNode } from '@azure/ms-rest-js';
 
 /**
  * Determines whether the object is a Delivery object.

--- a/lib/shims.d.ts
+++ b/lib/shims.d.ts
@@ -5,9 +5,11 @@
 // of amqp-common's surface area.
 
 // Shim for DOM's window and navigator's onLine status
+interface Navigator {
+  onLine: boolean;
+}
 interface Window {
-  navigator: {
-    onLine: boolean;
-  }
+  readonly navigator: Navigator
 }
 declare var window: Window;
+declare var navigator: Navigator

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -26,6 +26,10 @@ export interface AsyncLockOptions {
    */
   Promise?: any;
 }
+/**
+ * A constant that indicates whether the environment is node.js or browser based.
+ */
+export const isNode = typeof navigator === "undefined" && typeof process !== "undefined";
 
 /**
  * Describes the servicebus connection string model.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "module": "./dist-esm/lib/index.js",
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
+    "@azure/ms-rest-js": "^1.7.0",
     "@azure/ms-rest-nodeauth": "^0.9.1",
     "@types/is-buffer": "^2.0.0",
     "async-lock": "^1.1.3",
@@ -32,7 +33,6 @@
     "rhea-promise": "^0.1.14"
   },
   "devDependencies": {
-    "@azure/ms-rest-js": "^1.7.0",
     "@types/async-lock": "^1.1.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "module": "./dist-esm/lib/index.js",
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
-    "@azure/ms-rest-js": "^1.7.0",
     "@azure/ms-rest-nodeauth": "^0.9.1",
     "@types/is-buffer": "^2.0.0",
     "async-lock": "^1.1.3",

--- a/tests/context.spec.ts
+++ b/tests/context.spec.ts
@@ -7,7 +7,7 @@ import {
   ConnectionConfig, ConnectionContextBase, SasTokenProvider, DefaultDataTransformer, CbsClient
 } from "../lib";
 import { Connection } from "rhea-promise";
-import { isNode } from '@azure/ms-rest-js';
+import { isNode } from '../lib/util/utils';
 
 
 describe("ConnectionContextBase", function () {


### PR DESCRIPTION
xml2js is unrollupable due to very difficult to resolve circular references. The root cause though is the usage of `isNode` without `@azure/ms-rest-js` marked as a dependency in package.json, causing rollup to attempt to bundle. Simply adding @azure/ms-rest-js in the right place fixes the circular reference error @ShivangiReja was seeing.