### PR TITLE
Add a parameter for web socket options.

### DIFF
--- a/lib/ConnectionContextBase.ts
+++ b/lib/ConnectionContextBase.ts
@@ -168,7 +168,7 @@ export module ConnectionContextBase {
       const socket = parameters.config.webSocket || (window as any).WebSocket;
       const host = parameters.config.host;
       const endpoint = parameters.config.webSocketEndpointPath || "";
-      const socketOptions = parameters.config.webSocketConstructorOptions || "";
+      const socketOptions = parameters.config.webSocketConstructorOptions || {};
 
       connectionOptions.webSocketOptions = {
         webSocket: socket,

--- a/lib/ConnectionContextBase.ts
+++ b/lib/ConnectionContextBase.ts
@@ -140,7 +140,7 @@ export module ConnectionContextBase {
     if (userAgent.length > Constants.maxUserAgentLength) {
       throw new Error(
         `The user-agent string cannot be more than 128 characters in length.` +
-          `The given user-agent string is: ${userAgent} with length: ${userAgent.length}`
+        `The given user-agent string is: ${userAgent} with length: ${userAgent.length}`
       );
     }
 
@@ -168,11 +168,13 @@ export module ConnectionContextBase {
       const socket = parameters.config.webSocket || (window as any).WebSocket;
       const host = parameters.config.host;
       const endpoint = parameters.config.webSocketEndpointPath || "";
+      const socketOptions = parameters.config.webSocketConstructorOptions || "";
 
       connectionOptions.webSocketOptions = {
         webSocket: socket,
         url: `wss://${host}:443/${endpoint}`,
-        protocol: ["AMQPWSB10"]
+        protocol: ["AMQPWSB10"],
+        options: socketOptions
       };
     }
 

--- a/lib/connectionConfig/connectionConfig.ts
+++ b/lib/connectionConfig/connectionConfig.ts
@@ -61,10 +61,10 @@ export interface ConnectionConfig {
    * connection over WebSockets.
    */
   webSocketEndpointPath?: string;
-  /***
-     * @property {any} [webSocketConstructorOptions] - Options to be passed to the function returned by
-     * rhea.websocket_connect()
-     */
+
+  /**
+   * @property {any} [webSocketConstructorOptions] - Options to be passed to the WebSocket constructor
+   */
   webSocketConstructorOptions?: any;
 }
 

--- a/lib/connectionConfig/connectionConfig.ts
+++ b/lib/connectionConfig/connectionConfig.ts
@@ -2,26 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { parseConnectionString, ServiceBusConnectionStringModel } from "../util/utils";
-
-/**
- * Describes the required shape of WebSocket instances.
- * @interface WebSocketInstance
- */
-export interface WebSocketInstance {
-  send: Function;
-  onmessage: Function | null;
-  onopen: Function | null;
-  onclose: Function | null;
-  onerror: Function | null;
-}
-
-/**
- * Describes the required shape of WebSocket constructors.
- * @interface WebSocketImpl
- */
-export interface WebSocketImpl {
-  new(url: string, protocols?: string | string[]): WebSocketInstance;
-}
+import { WebSocketImpl } from "rhea-promise";
 
 /**
  * Describes the options that can be provided while creating a connection config.
@@ -80,6 +61,11 @@ export interface ConnectionConfig {
    * connection over WebSockets.
    */
   webSocketEndpointPath?: string;
+  /***
+     * @property {any} {webSocketConstructorOptions  } - Options to be passed to the function returned by
+     * rhea.websocket_connect()
+     */
+  webSocketConstructorOptions?: any;
 }
 
 /**

--- a/lib/connectionConfig/connectionConfig.ts
+++ b/lib/connectionConfig/connectionConfig.ts
@@ -62,7 +62,7 @@ export interface ConnectionConfig {
    */
   webSocketEndpointPath?: string;
   /***
-     * @property {any} {webSocketConstructorOptions  } - Options to be passed to the function returned by
+     * @property {any} [webSocketConstructorOptions] - Options to be passed to the function returned by
      * rhea.websocket_connect()
      */
   webSocketConstructorOptions?: any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1745,8 +1745,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1767,14 +1766,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1789,20 +1786,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1919,8 +1913,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1932,7 +1925,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1947,7 +1939,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1955,14 +1946,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1981,7 +1970,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2062,8 +2050,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2075,7 +2062,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2161,8 +2147,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2198,7 +2183,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2218,7 +2202,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2262,14 +2245,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4746,22 +4727,22 @@
       "dev": true
     },
     "rhea": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rhea/-/rhea-1.0.2.tgz",
-      "integrity": "sha512-ZbF1fe90TIu+nhzu5vvf9Xg4OhWO2p2FSGv97SBwPn2CpDy0CRjOxGQYu2eeqSukmZc9D+aQX6lOMQUF0pO16g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-1.0.6.tgz",
+      "integrity": "sha512-N7gt43xN8+R/U5vUCikljA7H9h28KpIJK40CrXfoodNEdg4NjCBg2MWT2SytNURI9I1A4SYiNsWawOD3WxrXxg==",
       "dev": true,
       "requires": {
         "debug": "0.8.0 - 3.5.0"
       }
     },
     "rhea-promise": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-0.1.14.tgz",
-      "integrity": "sha512-3wvslFhKfHDU9wxwLIO6K4gB8/h1PF/J17PeknqawDowVwIdJoupqj/QUBuflFr6ho/dO7mLbU71x00brmO+8w==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-0.1.15.tgz",
+      "integrity": "sha512-+6uilZXSJGyiqVeHQI3Krv6NTAd8cWRCY2uyCxmzR4/5IFtBqqFem1HV2OiwSj0Gu7OFChIJDfH2JyjN7J0vRA==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
-        "rhea": "^1.0.2",
+        "rhea": "^1.0.4",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "stream": "stream-browserify"
   },
   "peerDependencies": {
-    "rhea-promise": "^0.1.14"
+    "rhea-promise": "^0.1.15"
   },
   "devDependencies": {
     "@types/async-lock": "^1.1.0",
@@ -52,7 +52,7 @@
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^13.3.0",
-    "rhea-promise": "^0.1.14",
+    "rhea-promise": "^0.1.15",
     "rimraf": "^2.6.2",
     "rollup": "^1.1.2",
     "rollup-plugin-commonjs": "^9.2.0",


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
-  This pr adds one parameter `webSocketConstructorOptions` that takes web socket options(we can pass proxy information here)
-  Update rhea-promise version - All the ws types have been exposed from rhea hence using types directly from rhea-promise.